### PR TITLE
fix: karma hangs after finishing tests successfully

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -192,12 +192,14 @@ class Browser {
     if (this.noActivityTimeout) {
       this.clearNoActivityTimeout()
 
-      this.noActivityTimeoutId = this.timer.setTimeout(() => {
-        this.lastResult.totalTimeEnd()
-        this.lastResult.disconnected = true
-        this.disconnect(`, because no message in ${this.noActivityTimeout} ms.`)
-        this.emitter.emit('browser_complete', this)
-      }, this.noActivityTimeout)
+      if (this.state !== 'DISCONNECTED') {
+        this.noActivityTimeoutId = this.timer.setTimeout(() => {
+          this.lastResult.totalTimeEnd()
+          this.lastResult.disconnected = true
+          this.disconnect(`, because no message in ${this.noActivityTimeout} ms.`)
+          this.emitter.emit('browser_complete', this)
+        }, this.noActivityTimeout)
+      }
     }
   }
 


### PR DESCRIPTION
After successfully finishing all tests, karma hangs for 30 sec with this message:

Chrome Headless 114.0.5735.35 (Windows 10) ERROR
  Disconnected , because no message in 30000 ms.
Chrome Headless 114.0.5735.35 (Windows 10): Executed 634 of 634 DISCONNECTED (34.58 secs / 3.303 secs) Chrome Headless 114.0.5735.35 (Windows 10) ERROR
Chrome Headless 114.0.5735.35 (Windows 10): Executed 634 of 634 DISCONNECTED (34.58 secs / 3.303 secs)

This only happens when executing more than approx 620 tests.

See more details here: https://stackoverflow.com/questions/76457941/karma-hangs-for-30-seconds-after-successfully-executing-unit-tests